### PR TITLE
Default to soft purge

### DIFF
--- a/src/classes/purge-request.php
+++ b/src/classes/purge-request.php
@@ -79,7 +79,7 @@ class Purgely_Purge {
 
 		// Set up our default args.
 		$default_args = array(
-			'soft-purge' => false,
+			'purge-type' => ( defined( 'PURGELY_DEFAULT_PURGE_TYPE' ) ) ? PURGELY_DEFAULT_PURGE_TYPE : 'instant',
 		);
 
 		$purge_args = array_merge( $default_args, $purge_args );
@@ -179,7 +179,7 @@ class Purgely_Purge {
 	 * @return array The potentially modified remote request args.
 	 */
 	private function _maybe_add_soft_purge( $purge_args, $remote_request_args ) {
-		if ( isset( $purge_args['soft-purge'] ) && true === $purge_args['soft-purge'] ) {
+		if ( isset( $purge_args['purge-type'] ) && 'soft' === $purge_args['purge-type'] ) {
 			$remote_request_args = $this->_add_soft_purge( $remote_request_args );
 		}
 

--- a/src/config.php
+++ b/src/config.php
@@ -79,3 +79,14 @@ if ( ! defined( 'PURGELY_STALE_WHILE_ERROR_TTL' ) ) {
 if ( ! defined( 'PURGELY_SURROGATE_CONTROL_TTL' ) ) {
 	define( 'PURGELY_SURROGATE_CONTROL_TTL', 60 * 5 ); // 5 minutes
 }
+
+/**
+ * Set the default purge type for all purges.
+ *
+ * The currently supported values are "soft" and "instant".
+ *
+ * @since 1.0.0.
+ */
+if ( ! defined( 'PURGELY_DEFAULT_PURGE_TYPE' ) ) {
+	define( 'PURGELY_DEFAULT_PURGE_TYPE', 'soft' );
+}

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -31,7 +31,17 @@ if ( ! class_exists( 'Purgely_Command' ) ) :
 		 *
 		 * [--soft]
 		 *
-		 * : Issue a Fastly "soft purge" for the purge request or requests.
+		 * : Issue a Fastly "soft purge" for the purge request or requests. Note that the default behavior without this
+		 * flag depends on the PURGELY_DEFAULT_PURGE_TYPE configuration value. If PURGELY_DEFAULT_PURGE_TYPE is set to
+		 * "soft", soft purges will be issued by default. If PURGELY_DEFAULT_PURGE_TYPE is set to "instant",
+		 * setting the "soft" flag will change the purge to soft.
+		 *
+		 * [--instant]
+		 *
+		 * : Issue an instant Fastly purge for the purge request or requests. Note that the default behavior without
+		 * this flag depends on the PURGELY_DEFAULT_PURGE_TYPE configuration value. If PURGELY_DEFAULT_PURGE_TYPE is set
+		 * to "instant", instant purges will be issued by default. If PURGELY_DEFAULT_PURGE_TYPE is set to "soft",
+		 * setting the "instant" flag will change the purge to instant.
 		 *
 		 * ## EXAMPLES
 		 *
@@ -47,6 +57,7 @@ if ( ! class_exists( 'Purgely_Command' ) ) :
 		 *   # Add purge args
 		 *   wp fp http://www.wired.com/category/design/ --soft
 		 *   wp fp section-front --soft
+		 *   wp fp --all --instant
 		 *
 		 *   # Purge related URLs
 		 *   wp fp http://www.wired.com/2015/10/apple-google-war --related
@@ -74,9 +85,14 @@ if ( ! class_exists( 'Purgely_Command' ) ) :
 			$thing = ( isset( $args[0] ) ) ? $args[0] : '';
 
 			// Collect the secondary arguments.
-			$purge_args               = array();
-			$purge_args['soft-purge'] = ( isset( $assoc_args['soft'] ) ) ? true : false;
-			$purge_args['related']    = ( isset( $assoc_args['related'] ) ) ? true : false;
+			$purge_args            = array();
+			$purge_args['related'] = ( isset( $assoc_args['related'] ) ) ? true : false;
+
+			if ( isset( $assoc_args['soft'] ) ) {
+				$purge_args['purge-type'] = 'soft';
+			} else if ( $assoc_args['instant'] ) {
+				$purge_args['purge-type'] = 'instant';
+			}
 
 			// Determine the type of request.
 			if ( true === $this->_is_ids( $args ) ) {

--- a/test/tests/ConfigTest.php
+++ b/test/tests/ConfigTest.php
@@ -11,5 +11,6 @@ class ConfigTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( defined( 'PURGELY_ENABLE_STALE_WHILE_ERROR' ) );
 		$this->assertTrue( defined( 'PURGELY_STALE_WHILE_ERROR_TTL' ) );
 		$this->assertTrue( defined( 'PURGELY_SURROGATE_CONTROL_TTL' ) );
+		$this->assertTrue( defined( 'PURGELY_DEFAULT_PURGE_TYPE' ) );
 	}
 }

--- a/test/tests/PurgeRequestTest.php
+++ b/test/tests/PurgeRequestTest.php
@@ -15,6 +15,9 @@ class PurgeRequestTest extends PHPUnit_Framework_TestCase {
 				$url,
 				array(
 					'method' => 'PURGE',
+					'headers' => array(
+						'Fastly-Soft-Purge' => 1,
+					),
 				)
 			),
 			'times'  => 1,
@@ -43,6 +46,9 @@ class PurgeRequestTest extends PHPUnit_Framework_TestCase {
 				$url,
 				array(
 					'method' => 'PURGE',
+					'headers' => array(
+						'Fastly-Soft-Purge' => 1,
+					),
 				)
 			),
 			'times'  => 1,
@@ -71,7 +77,7 @@ class PurgeRequestTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'success', $purge->get_result() );
 	}
 
-	public function test_successful_purge_request_for_individual_url_with_soft_purge() {
+	public function test_successful_purge_request_for_individual_url_with_instant_purge() {
 		$url             = 'http://www.example.org/2015/05/test-post';
 		$expected_result = MockData::purge_url_response_200();
 
@@ -81,9 +87,6 @@ class PurgeRequestTest extends PHPUnit_Framework_TestCase {
 				$url,
 				array(
 					'method'  => 'PURGE',
-					'headers' => array(
-						'Fastly-Soft-Purge' => 1,
-					),
 				),
 			),
 			'times'  => 1,
@@ -91,7 +94,7 @@ class PurgeRequestTest extends PHPUnit_Framework_TestCase {
 		) );
 
 		$purge         = new Purgely_Purge();
-		$actual_result = $purge->purge( 'url', $url, array( 'soft-purge' => true ) );
+		$actual_result = $purge->purge( 'url', $url, array( 'purge-type' => 'instant' ) );
 
 		$this->assertEquals( $expected_result, $actual_result );
 		$this->assertEquals( $expected_result, $purge->get_response() );
@@ -122,6 +125,9 @@ class PurgeRequestTest extends PHPUnit_Framework_TestCase {
 				$url,
 				array(
 					'method' => 'PURGE',
+					'headers' => array(
+						'Fastly-Soft-Purge' => 1,
+					),
 				)
 			),
 			'times'  => 1,
@@ -163,6 +169,7 @@ class PurgeRequestTest extends PHPUnit_Framework_TestCase {
 					'method'  => 'POST',
 					'headers' => array(
 						'Fastly-Key' => PURGELY_FASTLY_KEY,
+						'Fastly-Soft-Purge' => 1,
 					),
 				),
 			),
@@ -211,6 +218,7 @@ class PurgeRequestTest extends PHPUnit_Framework_TestCase {
 					'method'  => 'POST',
 					'headers' => array(
 						'Fastly-Key' => PURGELY_FASTLY_KEY,
+						'Fastly-Soft-Purge' => 1,
 					),
 				),
 			),
@@ -258,6 +266,7 @@ class PurgeRequestTest extends PHPUnit_Framework_TestCase {
 					'method'  => 'POST',
 					'headers' => array(
 						'Fastly-Key' => PURGELY_FASTLY_KEY,
+						'Fastly-Soft-Purge' => 1,
 					),
 				),
 			),


### PR DESCRIPTION
Instead of instant purging by default, the plugin is transitioning to
providing soft purges by default. This decision was made in order to
provide the most reliable experience for various WP installs. Soft purge
is an excellent default experience as it allows for stale content to be
served while a cached is revalidated.

In order to facilitate this change, I reconceptualized the notion of
soft purge and not soft purge into a "purge type" value. You can now
have a "soft" and "instant" purge type. This language is now reflected
in a configuration value, WP CLI, and labelling throughout the code
base. This is a forward thinking refactor in that it allows for support
for future purge types (whether a Fastly implement thing or not).
