### PR TITLE
Add surrogate keys for archive pages

### DIFF
--- a/test/tests/SurrogateKeyCollectionTest.php
+++ b/test/tests/SurrogateKeyCollectionTest.php
@@ -243,6 +243,90 @@ class SurrogateKeyCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( $expected_keys, $object->get_keys() );
 	}
 
+	public function test_tag_page_keys() {
+		$wp_query = $this->getMockBuilder( 'WP_Query' )
+			->setMethods( array(
+				'get_queried_object',
+				'get',
+				'is_single',
+				'is_preview',
+				'is_page',
+				'is_archive',
+				'is_date',
+				'is_year',
+				'is_month',
+				'is_day',
+				'is_time',
+				'is_author',
+				'is_category',
+				'is_tag',
+				'is_tax',
+				'is_search',
+				'is_feed',
+				'is_comment_feed',
+				'is_trackback',
+				'is_home',
+				'is_404',
+				'is_comments_popup',
+				'is_paged',
+				'is_admin',
+				'is_attachment',
+				'is_singular',
+				'is_robots',
+				'is_posts_page',
+				'is_post_type_archive',
+			) )
+			->getMock();
+
+		$template_type = 'tag';
+
+		$wp_query->expects( $this->any() )
+			->method( 'is_tag' )
+			->will( $this->returnValue( true ) );
+
+		$wp_query->post              = $this->getMockBuilder( 'WP_Post' )->getMock();
+		$wp_query->post->ID          = 10;
+		$wp_query->post->post_author = 23;
+
+		$post2              = $this->getMockBuilder( 'WP_Post' )->getMock();
+		$post2->ID          = 11;
+		$post2->post_author = 54;
+
+		$wp_query->posts = array(
+			clone $wp_query->post,
+			clone $post2,
+		);
+
+		$tag = (object) array(
+			'term_id'          => '4',
+			'name'             => 'Ham',
+			'slug'             => 'ham',
+			'term_group'       => '',
+			'term_taxonomy_id' => '23',
+			'taxonomy'         => 'post_tag',
+			'description'      => '',
+			'parent'           => '',
+			'count'            => '64'
+		);
+
+		\WP_Mock::wpFunction( 'get_queried_object', array(
+			'args'   => array(),
+			'times'  => 1,
+			'return' => $tag
+		) );
+
+		$object = new Purgely_Surrogate_Key_Collection( $wp_query );
+
+		$expected_keys = array (
+			0 => 'post-' . $wp_query->post->ID ,
+			1 => 'post-' . $post2->ID ,
+			2 => 'template-' . $template_type,
+			3 => 'post_tag-' . $tag->slug,
+		);
+
+		$this->assertEquals( $expected_keys, $object->get_keys() );
+	}
+
 	public function test_home_page_keys() {
 		$wp_query = $this->getMockBuilder( 'WP_Query' )
 			->setMethods( array(

--- a/test/tests/SurrogateKeyCollectionTest.php
+++ b/test/tests/SurrogateKeyCollectionTest.php
@@ -121,6 +121,12 @@ class SurrogateKeyCollectionTest extends PHPUnit_Framework_TestCase {
 			)
 		);
 
+		\WP_Mock::wpFunction( 'get_queried_object', array(
+			'args'   => array(),
+			'times'  => 5,
+			'return' => $wp_query->post
+		) );
+
 		\WP_Mock::wpFunction( 'get_the_terms', array(
 			'args' => array(
 				\WP_Mock\Functions::type( 'int' ),
@@ -207,12 +213,31 @@ class SurrogateKeyCollectionTest extends PHPUnit_Framework_TestCase {
 			clone $post2,
 		);
 
+		$category = (object) array(
+			'term_id'          => '4',
+			'name'             => 'Ham',
+			'slug'             => 'ham',
+			'term_group'       => '',
+			'term_taxonomy_id' => '23',
+			'taxonomy'         => 'category',
+			'description'      => '',
+			'parent'           => '',
+			'count'            => '64'
+		);
+
+		\WP_Mock::wpFunction( 'get_queried_object', array(
+			'args'   => array(),
+			'times'  => 1,
+			'return' => $category
+		) );
+
 		$object = new Purgely_Surrogate_Key_Collection( $wp_query );
 
 		$expected_keys = array (
 			0 => 'post-' . $wp_query->post->ID ,
 			1 => 'post-' . $post2->ID ,
 			2 => 'template-' . $template_type,
+			3 => 'category-' . $category->slug,
 		);
 
 		$this->assertEquals( $expected_keys, $object->get_keys() );


### PR DESCRIPTION
If a tag pages is showing content for "apple", it should be the `post_tag-apple` surrogate key.
