### PR TITLE
Fix purging of front page

### DIFF
--- a/src/wp-purges.php
+++ b/src/wp-purges.php
@@ -46,7 +46,18 @@ class Purgely_Purges {
 			return;
 		}
 
-		purgely_purge_surrogate_key( 'post-' . absint( $post_id ) );
+		$ids[] = ( 'post-' . absint( $post_id ) );
+
+		$parent_id = wp_is_post_revision( $post_id );
+		if ( defined ( $parent_id) ) {
+			$ids[] = 'post-' . absint( $parent_id );
+		} else {
+			$ids[] = 'template-home';
+		}
+
+		foreach ( $ids as $id ) {
+			purgely_purge_surrogate_key( $id );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Purge the front page when a new post is created.

Purge the parent id if the post is a revision.

Fixes #27
