### PR TITLE
Add "Force Purge All" setting.

### DIFF
--- a/src/classes/settings.php
+++ b/src/classes/settings.php
@@ -61,6 +61,10 @@ class Purgely_Settings {
 				'sanitize_callback' => 'sanitize_key',
 				'default'           => PURGELY_DEFAULT_PURGE_TYPE,
 			),
+			'force_purge_all'               => array(
+				'sanitize_callback' => 'purgely_sanitize_checkbox',
+				'default'           => PURGELY_FORCE_PURGE_ALL,
+			),
 		);
 	}
 

--- a/src/config.php
+++ b/src/config.php
@@ -90,3 +90,12 @@ if ( ! defined( 'PURGELY_SURROGATE_CONTROL_TTL' ) ) {
 if ( ! defined( 'PURGELY_DEFAULT_PURGE_TYPE' ) ) {
 	define( 'PURGELY_DEFAULT_PURGE_TYPE', 'soft' );
 }
+
+/**
+ * Force all-cache purges when updating posts.
+ *
+ * @since 1.0.1.
+ */
+if ( ! defined( 'PURGELY_FORCE_PURGE_ALL' ) ) {
+	define( 'PURGELY_FORCE_PURGE_ALL', false );
+}

--- a/src/settings-page.php
+++ b/src/settings-page.php
@@ -176,6 +176,14 @@ class Purgely_Settings_Page {
 			'purgely-settings',
 			'purgely-stale_settings'
 		);
+
+		add_settings_field(
+			'force_purge_all',
+			__( 'Force All Cache Purges', 'purgely' ),
+			array( $this, 'stale_if_error_ttl_render' ),
+			'purgely-settings',
+			'purgely-general_settings'
+		);
 	}
 
 	/**
@@ -438,6 +446,24 @@ class Purgely_Settings_Page {
 		<input type='text' name='purgely-settings[stale_if_error_ttl]' value='<?php echo esc_attr( $options['stale_if_error_ttl'] ); ?>'>
 		<p class="description">
 			<?php esc_html_e( 'This setting determines the amount of time that stale content will be served while the origin is returning an error state.', 'purgely' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render the setting input.
+	 *
+	 * @since 1.0.1.
+	 *
+	 * @return void
+	 */
+	public function force_purge_all_render() {
+		$options = Purgely_Settings::get_settings();
+		?>
+		<input type='radio' name='purgely-settings[force_purge_all]' <?php checked( isset( $options['force_purge_all'] ) && true === $options['force_purge_all'] ); ?> value='true'>Yes&nbsp;
+		<input type='radio' name='purgely-settings[force_purge_all]' <?php checked( isset( $options['force_purge_all'] ) && false === $options['force_purge_all'] ); ?> value='false'>No
+		<p class="description">
+			<?php esc_html_e( 'Force purging entire site whenever a post is updated. The full cache purging behavior available to WP CLI must be explicitly enabled in order for it to work. Purging the entire cache can cause significant site stability issues and is disable by default.', 'purgely' ); ?>
 		</p>
 		<?php
 	}

--- a/src/wp-purges.php
+++ b/src/wp-purges.php
@@ -46,6 +46,11 @@ class Purgely_Purges {
 			return;
 		}
 
+		if ( true === Purgely_Settings::get_setting( 'force_purge_all' ) ) {
+			purgely_purge_all();
+			return;
+		}
+
 		purgely_purge_surrogate_key( 'post-' . absint( $post_id ) );
 	}
 

--- a/test/tests/ConfigTest.php
+++ b/test/tests/ConfigTest.php
@@ -12,5 +12,6 @@ class ConfigTest extends PurgelyBase {
 		$this->assertTrue( defined( 'PURGELY_STALE_IF_ERROR_TTL' ) );
 		$this->assertTrue( defined( 'PURGELY_SURROGATE_CONTROL_TTL' ) );
 		$this->assertTrue( defined( 'PURGELY_DEFAULT_PURGE_TYPE' ) );
+		$this->assertTrue( defined( 'PURGELY_FORCE_PURGE_ALL' ) );
 	}
 }


### PR DESCRIPTION
Allow a setting which always does a purge-all for every post update.

Not recommended but potentially useful in the nuclear case.

Fixes #28
