### PR TITLE
Purge the URL for the post if the service ID isn't set

### DIFF
--- a/src/wp-purges.php
+++ b/src/wp-purges.php
@@ -46,7 +46,11 @@ class Purgely_Purges {
 			return;
 		}
 
-		purgely_purge_surrogate_key( 'post-' . absint( $post_id ) );
+		if ( isset( Purgely_Settings::get_setting( 'fastly_service_id') ) ) {
+			purgely_purge_surrogate_key( 'post-' . absint( $post_id ) );
+		} else {
+			purgely_purge_url( get_permalink( $post_id ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
This is for users who mix and match two different services (e.g static and dynamic content).

It does _not_ purge related content. It probably should.

One problem is that `get_permalink($post_id)` can optionally return the url with or without the post name being included.

I'm not sure whether we:
- can find out programatically which one is being used by this WP install
- should purge both?
- should tell customers doing this that they should remove the name in vcl_hash
