### PR TITLE
Apply filtered Surrogate-Control TTL value

### DIFF
--- a/purgely.php
+++ b/purgely.php
@@ -238,7 +238,6 @@ class Purgely {
 		$surrogate_control = $this::$surrogate_control_header;
 		$seconds = apply_filters( 'purgely_surrogate_control', $surrogate_control->get_seconds() );
 		$surrogate_control->set_seconds( $seconds );
-		$surrogate_control->set_value( $surrogate_control->prepare_value( $seconds ) );
 
 		do_action( 'purgely_pre_send_surrogate_control', $seconds );
 		$surrogate_control->send_header();

--- a/purgely.php
+++ b/purgely.php
@@ -237,6 +237,8 @@ class Purgely {
 
 		$surrogate_control = $this::$surrogate_control_header;
 		$seconds = apply_filters( 'purgely_surrogate_control', $surrogate_control->get_seconds() );
+		$surrogate_control->set_seconds( $seconds );
+		$surrogate_control->set_value( $surrogate_control->prepare_value( $seconds ) );
 
 		do_action( 'purgely_pre_send_surrogate_control', $seconds );
 		$surrogate_control->send_header();

--- a/src/classes/header-surrogate-control.php
+++ b/src/classes/header-surrogate-control.php
@@ -61,5 +61,6 @@ class Purgely_Surrogate_Control_Header extends Purgely_Header {
 	 */
 	public function set_seconds( $seconds ) {
 		$this->_seconds = $seconds;
+		$this->set_value( $this->prepare_value( $seconds ) );
 	}
 }


### PR DESCRIPTION
### Overview

While trying to find a solution to serve different TTLs for different page types I noticed that applied changes to the `purgely_surrogate_control` filter never make it through to the headers.
### Details

Seems like this is a known issue but was never addressed. As we will likely require this functionality in the near future we thought it would make sense to fix that upstream. I'm happy to update/add specs where required if there's an interest in getting this fix merged.
### Related issue

https://github.com/CondeNast/purgely/issues/26
