### PR TITLE
Deprecated WP function is_comments_popup()

### DIFF
--- a/src/classes/surrogate-key-collection.php
+++ b/src/classes/surrogate-key-collection.php
@@ -122,7 +122,6 @@ class Purgely_Surrogate_Key_Collection {
 				'trackback',
 				'home',
 				'404',
-				'comments_popup',
 				'paged',
 				'admin',
 				'attachment',


### PR DESCRIPTION
Removing `is_comments_popup` call since is deprecated and is trowing PHP notices in the backend.

Fixes #36 